### PR TITLE
re-throw errors on web-socket send to fail the pipeline

### DIFF
--- a/hkube_python_wrapper/wc.py
+++ b/hkube_python_wrapper/wc.py
@@ -55,6 +55,7 @@ class WebsocketClient:
             self._ws.send(json.dumps(message))
         except Exception as e:
             print(e)
+            raise
 
     def startWS(self, url):
         self._ws = websocket.WebSocketApp(


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-hpc/python-wrapper.hkube/1)
<!-- Reviewable:end -->
