### PR TITLE
Bug wrapper algorunner out of memory

### DIFF
--- a/hkube_python_wrapper/wrapper/algorunner.py
+++ b/hkube_python_wrapper/wrapper/algorunner.py
@@ -52,7 +52,7 @@ class Algorunner(DaemonThread):
         self._stopped = False
         self._redirectLogs = False
         self._printThread = 0
-        self._done = False
+        self._done = True
         DaemonThread.__init__(self, "WorkerListener")
 
     @staticmethod
@@ -319,10 +319,10 @@ class Algorunner(DaemonThread):
 
     def _aliveSignal(self):
         def routine():
-            while not self._done:
-                time.sleep(5)
+            while not self._done and not self.stopped:
                 self._sendCommand(messages.outgoing.alive, None)
                 print("stopped is: ", self._stopped)
+                time.sleep(5)
 
         thread = threading.Thread(target=routine)
         thread.start()
@@ -356,7 +356,6 @@ class Algorunner(DaemonThread):
                 redirector.flush()
                 redirector.events.on_data -= self._log_message
                 redirector.cleanup()
-
 
     def _discovery_update(self, discovery):
         log.debug('Got discovery update {discovery}', discovery=discovery)

--- a/hkube_python_wrapper/wrapper/algorunner.py
+++ b/hkube_python_wrapper/wrapper/algorunner.py
@@ -418,8 +418,8 @@ class Algorunner(DaemonThread):
                     method(self._input)
             method = self._getMethod('start')
             algorithmData = method(self._input, self._hkubeApi)
+            self._done = True
             if not (self._stopped):
-                self._done = True
                 self._handle_response(algorithmData, jobId, taskId, nodeName, savePaths, span)
 
         except Exception as e:

--- a/hkube_python_wrapper/wrapper/messages.py
+++ b/hkube_python_wrapper/wrapper/messages.py
@@ -22,6 +22,7 @@ class Outgoing(object):
         self.streamingOutMessage = "streamingOutMessage"
         self.streamingInMessageDone = "streamingInMessageDone"
         self.logData = "logData"
+        self.alive = "alive"
 
 
 class Incoming(object):


### PR DESCRIPTION
Added a method to run a thread that periodically sends a signal to indicate the wrapper is still alive.
Issue: kube-HPC/hkube#1975

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/python-wrapper.hkube/128)
<!-- Reviewable:end -->
